### PR TITLE
Blur bench

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 mod blur;
 
 use anyhow::{bail, Result};
-use blur::Blur;
+pub use blur::Blur;
 pub use yuvxyb::{CastFromPrimitive, Frame, LinearRgb, Pixel, Plane, Rgb, Xyb, Yuv};
 pub use yuvxyb::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic, YuvConfig};
 


### PR DESCRIPTION
Adds benchmark for blur to allow for easy performance validation. We can test with any size image just by changing the path on line 120.