### PR TITLE
Replace anyhow with concrete error type (via thiserror)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ssimulacra2"
 version = "0.4.0"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.65.0"
 description = "Rust implementation of the SSIMULACRA2 metric"
 repository = "https://github.com/rust-av/ssimulacra2"
 homepage = "https://github.com/rust-av/ssimulacra2"
@@ -15,10 +15,10 @@ default = ["rayon"]
 
 [dependencies]
 aligned = "0.4.1"
-anyhow = "1.0.0"
 nalgebra = "0.32.2"
 num-traits = "0.2.15"
 rayon = { version = "1.5.3", optional = true }
+thiserror = "1.0.56"
 wide = "0.7.5"
 yuvxyb = "0.3.0"
 

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -6,12 +6,11 @@ use nalgebra::base::{Matrix3, Matrix3x1};
 /// Structure handling image blur.
 ///
 /// This struct contains the necessary buffers and the kernel used for blurring
-/// (currently a recursive Gaussian algorithm).
+/// (currently a recursive approximation of the Gaussian filter).
 /// 
-/// Note that the width and height of the image passed to [blur][Self::blur]
-/// needs to exactly match the width and height of this instance. If you reduce
-/// the image size (e.g. via downscaling), [shrink_to][Self::shrink_to] can be
-/// used to resize the internal buffers.
+/// Note that the width and height of the image passed to [blur][Self::blur] needs to exactly
+/// match the width and height of this instance. If you reduce the image size (e.g. via
+/// downscaling), [`shrink_to`][Self::shrink_to] can be used to resize the internal buffers.
 pub struct Blur {
     kernel: RecursiveGaussian,
     temp: Vec<f32>,
@@ -32,11 +31,10 @@ impl Blur {
         }
     }
 
-    /// Truncates the internal buffers to fit images of the given width and
-    /// height.
+    /// Truncates the internal buffers to fit images of the given width and height.
     /// 
-    /// This will [truncate][Vec::truncate] the internal buffers without
-    /// affecting the allocated memory.
+    /// This will [truncate][Vec::truncate] the internal buffers
+    /// without affecting the allocated memory.
     pub fn shrink_to(&mut self, width: usize, height: usize) {
         self.temp.truncate(width * height);
         self.width = width;

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -3,6 +3,15 @@ use std::f64::consts::PI;
 use aligned::{Aligned, A16};
 use nalgebra::base::{Matrix3, Matrix3x1};
 
+/// Structure handling image blur.
+///
+/// This struct contains the necessary buffers and the kernel used for blurring
+/// (currently a recursive Gaussian algorithm).
+/// 
+/// Note that the width and height of the image passed to [blur][Self::blur]
+/// needs to exactly match the width and height of this instance. If you reduce
+/// the image size (e.g. via downscaling), [shrink_to][Self::shrink_to] can be
+/// used to resize the internal buffers.
 pub struct Blur {
     kernel: RecursiveGaussian,
     temp: Vec<f32>,
@@ -11,6 +20,8 @@ pub struct Blur {
 }
 
 impl Blur {
+    /// Create a new [Blur] for images of the given width and height.
+    /// This pre-allocates the necessary buffers.
     #[must_use]
     pub fn new(width: usize, height: usize) -> Self {
         Blur {
@@ -21,12 +32,18 @@ impl Blur {
         }
     }
 
+    /// Truncates the internal buffers to fit images of the given width and
+    /// height.
+    /// 
+    /// This will [truncate][Vec::truncate] the internal buffers without
+    /// affecting the allocated memory.
     pub fn shrink_to(&mut self, width: usize, height: usize) {
         self.temp.truncate(width * height);
         self.width = width;
         self.height = height;
     }
 
+    /// Blur the given image.
     pub fn blur(&mut self, img: &[Vec<f32>; 3]) -> [Vec<f32>; 3] {
         [
             self.blur_plane(&img[0]),


### PR DESCRIPTION
I also added some docs on the public types (`cargo doc --open` is still looking a bit sad, I think I might add some docs to yuvxyb).

The new MSRV 1.65 was released in [November 2022](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html) which should be fine IMHO. It allows us to use let-else syntax which looks a bit nicer than `.map_err(|_| /* our error */)?;`

The inversion of trait bounds (`T: TryInto<LinearRgb>` -> `LinearRgb: TryFrom<T>`) *shouldn't* cause any problems. It's technically breaking (no-std environments don't have blanket `T: TryInto<U>` for all `U: TryFrom<T>` AFAIK) but practically isn't. (I preferred TryFrom over TryInto because it's what yuvxyb actually implements.)

The concrete error type is an actual breaking change though.