### PR TITLE
Precalculate float consts for RecursiveGaussian at build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ license = "BSD-2-Clause"
 default = ["rayon"]
 
 [dependencies]
-aligned = "0.4.1"
-nalgebra = "0.32.2"
 num-traits = "0.2.15"
 rayon = { version = "1.5.3", optional = true }
 thiserror = "1.0.56"
-wide = "0.7.5"
 yuvxyb = "0.3.0"
+
+[build-dependencies]
+nalgebra = "0.32.2"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,141 @@
+use std::env;
+use std::f64::consts::PI;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+use nalgebra::{Matrix3, Matrix3x1};
+
+fn main() {
+    let out_dir = &env::var("OUT_DIR").expect("can read OUT_DIR");
+
+    init_recursive_gaussian(out_dir).expect("can init recursive gaussian");
+}
+
+fn write_const_f32<W: Write>(w: &mut W, name: &str, val: f32) -> io::Result<()> {
+    writeln!(w, "const {name}: f32 = {val}_f32;")
+}
+
+fn write_const_usize<W: Write>(w: &mut W, name: &str, val: usize) -> io::Result<()> {
+    writeln!(w, "const {name}: usize = {val}_usize;")
+}
+
+fn init_recursive_gaussian(out_path: &str) -> io::Result<()> {
+    const SIGMA: f64 = 1.5f64;
+
+    // (57), "N"
+    let radius = 3.2795f64.mul_add(SIGMA, 0.2546).round();
+
+    // Table I, first row
+    let pi_div_2r = PI / (2.0f64 * radius);
+    let omega = [pi_div_2r, 3.0f64 * pi_div_2r, 5.0f64 * pi_div_2r];
+
+    // (37), k={1,3,5}
+    let p_1 = 1.0f64 / (0.5 * omega[0]).tan();
+    let p_3 = -1.0f64 / (0.5 * omega[1]).tan();
+    let p_5 = 1.0f64 / (0.5 * omega[2]).tan();
+
+    // (44), k={1,3,5}
+    let r_1 = p_1 * p_1 / omega[0].sin();
+    let r_3 = -p_3 * p_3 / omega[1].sin();
+    let r_5 = p_5 * p_5 / omega[2].sin();
+
+    // (50), k={1,3,5}
+    let neg_half_sigma2 = -0.5f64 * SIGMA * SIGMA;
+    let recip_radius = 1.0f64 / radius;
+    let mut rho = [0.0f64; 3];
+    for i in 0..3 {
+        rho[i] = (neg_half_sigma2 * omega[i] * omega[i]).exp() * recip_radius;
+    }
+
+    // second part of (52), k1,k2 = 1,3; 3,5; 5,1
+    let d_13 = p_1.mul_add(r_3, -r_1 * p_3);
+    let d_35 = p_3.mul_add(r_5, -r_3 * p_5);
+    let d_51 = p_5.mul_add(r_1, -r_5 * p_1);
+
+    // (52), k=5
+    let recip_d13 = 1.0f64 / d_13;
+    let zeta_15 = d_35 * recip_d13;
+    let zeta_35 = d_51 * recip_d13;
+
+    // (56)
+    let a = Matrix3::from_row_slice(&[p_1, p_3, p_5, r_1, r_3, r_5, zeta_15, zeta_35, 1.0f64])
+        .try_inverse()
+        .expect("Has inverse");
+    // (55)
+    let gamma = Matrix3x1::from_column_slice(&[
+        1.0f64,
+        radius.mul_add(radius, -SIGMA * SIGMA),
+        zeta_15.mul_add(rho[0], zeta_35 * rho[1]) + rho[2],
+    ]);
+    // (53)
+    let beta = a * gamma;
+
+    // Sanity check: correctly solved for beta (IIR filter weights are normalized)
+    // (39)
+    let sum = beta[2].mul_add(p_5, beta[0].mul_add(p_1, beta[1] * p_3));
+    assert!((sum - 1.0).abs() < 1E-12f64);
+
+    let mut n2 = [0f64; 3];
+    let mut d1 = [0f64; 3];
+    let mut mul_prev = [0f32; 3 * 4];
+    let mut mul_prev2 = [0f32; 3 * 4];
+    let mut mul_in = [0f32; 3 * 4];
+    for i in 0..3 {
+        // (33)
+        n2[i] = -beta[i] * (omega[i] * (radius + 1.0)).cos();
+        d1[i] = -2.0f64 * omega[i].cos();
+
+        let d_2 = d1[i] * d1[i];
+
+        // Obtained by expanding (35) for four consecutive outputs via
+        // sympy: n, d, p, pp = symbols('n d p pp')
+        // i0, i1, i2, i3 = symbols('i0 i1 i2 i3')
+        // o0, o1, o2, o3 = symbols('o0 o1 o2 o3')
+        // o0 = n*i0 - d*p - pp
+        // o1 = n*i1 - d*o0 - p
+        // o2 = n*i2 - d*o1 - o0
+        // o3 = n*i3 - d*o2 - o1
+        // Then expand(o3) and gather terms for p(prev), pp(prev2) etc.
+        mul_prev[4 * i] = -d1[i] as f32;
+        mul_prev[4 * i + 1] = (d_2 - 1.0f64) as f32;
+        mul_prev[4 * i + 2] = (-d_2).mul_add(d1[i], 2.0f64 * d1[i]) as f32;
+        mul_prev[4 * i + 3] = d_2.mul_add(d_2, 3.0f64.mul_add(-d_2, 1.0f64)) as f32;
+        mul_prev2[4 * i] = -1.0f32;
+        mul_prev2[4 * i + 1] = d1[i] as f32;
+        mul_prev2[4 * i + 2] = (-d_2 + 1.0f64) as f32;
+        mul_prev2[4 * i + 3] = d_2.mul_add(d1[i], -2.0f64 * d1[i]) as f32;
+        mul_in[4 * i] = n2[i] as f32;
+        mul_in[4 * i + 1] = (-d1[i] * n2[i]) as f32;
+        mul_in[4 * i + 2] = d_2.mul_add(n2[i], -n2[i]) as f32;
+        mul_in[4 * i + 3] = (-d_2 * d1[i]).mul_add(n2[i], 2.0f64 * d1[i] * n2[i]) as f32;
+    }
+
+    let file_path = Path::new(out_path).join("recursive_gaussian.rs");
+    let mut out_file = File::create(file_path)?;
+
+    write_const_usize(&mut out_file, "RADIUS", radius as usize)?;
+
+    write_const_f32(&mut out_file, "VERT_MUL_IN_1", n2[0] as f32)?;
+    write_const_f32(&mut out_file, "VERT_MUL_IN_3", n2[1] as f32)?;
+    write_const_f32(&mut out_file, "VERT_MUL_IN_5", n2[2] as f32)?;
+
+    write_const_f32(&mut out_file, "VERT_MUL_PREV_1", d1[0] as f32)?;
+    write_const_f32(&mut out_file, "VERT_MUL_PREV_3", d1[1] as f32)?;
+    write_const_f32(&mut out_file, "VERT_MUL_PREV_5", d1[2] as f32)?;
+
+    write_const_f32(&mut out_file, "MUL_IN_1", mul_in[0])?;
+    write_const_f32(&mut out_file, "MUL_IN_3", mul_in[4])?;
+    write_const_f32(&mut out_file, "MUL_IN_5", mul_in[8])?;
+
+    write_const_f32(&mut out_file, "MUL_PREV_1", mul_prev[0])?;
+    write_const_f32(&mut out_file, "MUL_PREV_3", mul_prev[4])?;
+    write_const_f32(&mut out_file, "MUL_PREV_5", mul_prev[8])?;
+
+    write_const_f32(&mut out_file, "MUL_PREV2_1", mul_prev2[0])?;
+    write_const_f32(&mut out_file, "MUL_PREV2_3", mul_prev2[4])?;
+    write_const_f32(&mut out_file, "MUL_PREV2_5", mul_prev2[8])?;
+
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -14,11 +14,11 @@ fn main() {
 }
 
 fn write_const_f32<W: Write>(w: &mut W, name: &str, val: f32) -> io::Result<()> {
-    writeln!(w, "const {name}: f32 = {val}_f32;")
+    writeln!(w, "pub const {name}: f32 = {val}_f32;")
 }
 
 fn write_const_usize<W: Write>(w: &mut W, name: &str, val: usize) -> io::Result<()> {
-    writeln!(w, "const {name}: usize = {val}_usize;")
+    writeln!(w, "pub const {name}: usize = {val}_usize;")
 }
 
 fn init_recursive_gaussian(out_path: &str) -> io::Result<()> {

--- a/src/blur/gaussian.rs
+++ b/src/blur/gaussian.rs
@@ -3,66 +3,9 @@ use std::f64::consts::PI;
 use aligned::{Aligned, A16};
 use nalgebra::base::{Matrix3, Matrix3x1};
 
-/// Structure handling image blur.
-///
-/// This struct contains the necessary buffers and the kernel used for blurring
-/// (currently a recursive approximation of the Gaussian filter).
-/// 
-/// Note that the width and height of the image passed to [blur][Self::blur] needs to exactly
-/// match the width and height of this instance. If you reduce the image size (e.g. via
-/// downscaling), [`shrink_to`][Self::shrink_to] can be used to resize the internal buffers.
-pub struct Blur {
-    kernel: RecursiveGaussian,
-    temp: Vec<f32>,
-    width: usize,
-    height: usize,
-}
-
-impl Blur {
-    /// Create a new [Blur] for images of the given width and height.
-    /// This pre-allocates the necessary buffers.
-    #[must_use]
-    pub fn new(width: usize, height: usize) -> Self {
-        Blur {
-            kernel: RecursiveGaussian::new(),
-            temp: vec![0.0f32; width * height],
-            width,
-            height,
-        }
-    }
-
-    /// Truncates the internal buffers to fit images of the given width and height.
-    /// 
-    /// This will [truncate][Vec::truncate] the internal buffers
-    /// without affecting the allocated memory.
-    pub fn shrink_to(&mut self, width: usize, height: usize) {
-        self.temp.truncate(width * height);
-        self.width = width;
-        self.height = height;
-    }
-
-    /// Blur the given image.
-    pub fn blur(&mut self, img: &[Vec<f32>; 3]) -> [Vec<f32>; 3] {
-        [
-            self.blur_plane(&img[0]),
-            self.blur_plane(&img[1]),
-            self.blur_plane(&img[2]),
-        ]
-    }
-
-    fn blur_plane(&mut self, plane: &[f32]) -> Vec<f32> {
-        let mut out = vec![0f32; self.width * self.height];
-        self.kernel
-            .horizontal_pass(plane, &mut self.temp, self.width);
-        self.kernel
-            .vertical_pass_chunked::<128, 32>(&self.temp, &mut out, self.width, self.height);
-        out
-    }
-}
-
 /// Implements "Recursive Implementation of the Gaussian Filter Using Truncated
 /// Cosine Functions" by Charalampidis [2016].
-struct RecursiveGaussian {
+pub struct RecursiveGaussian {
     radius: usize,
     /// For k={1,3,5} in that order.
     vert_mul_in: [f32; 3],

--- a/src/blur/gaussian.rs
+++ b/src/blur/gaussian.rs
@@ -1,129 +1,10 @@
-use std::f64::consts::PI;
-
-use aligned::{Aligned, A16};
-use nalgebra::base::{Matrix3, Matrix3x1};
+include!(concat!(env!("OUT_DIR"), "/recursive_gaussian.rs"));
 
 /// Implements "Recursive Implementation of the Gaussian Filter Using Truncated
 /// Cosine Functions" by Charalampidis [2016].
-pub struct RecursiveGaussian {
-    radius: usize,
-    /// For k={1,3,5} in that order.
-    vert_mul_in: [f32; 3],
-    vert_mul_prev: [f32; 3],
-    /// We unroll horizontal passes 4x - one output per lane. These are each
-    /// lane's multiplier for the previous output (relative to the first of
-    /// the four outputs). Indexing: 4 * 0..2 (for {1,3,5}) + 0..3 for the
-    /// lane index.
-    mul_prev: Aligned<A16, [f32; 3 * 4]>,
-    /// Ditto for the second to last output.
-    mul_prev2: Aligned<A16, [f32; 3 * 4]>,
-    /// We multiply a vector of inputs 0..3 by a vector shifted from this array.
-    /// in=0 uses all 4 (nonzero) terms; for in=3, the lower three lanes are 0.
-    mul_in: Aligned<A16, [f32; 3 * 4]>,
-}
+pub struct RecursiveGaussian;
 
 impl RecursiveGaussian {
-    pub fn new() -> Self {
-        const SIGMA: f64 = 1.5f64;
-
-        // (57), "N"
-        let radius = 3.2795f64.mul_add(SIGMA, 0.2546).round();
-
-        // Table I, first row
-        let pi_div_2r = PI / (2.0f64 * radius);
-        let omega = [pi_div_2r, 3.0f64 * pi_div_2r, 5.0f64 * pi_div_2r];
-
-        // (37), k={1,3,5}
-        let p_1 = 1.0f64 / (0.5 * omega[0]).tan();
-        let p_3 = -1.0f64 / (0.5 * omega[1]).tan();
-        let p_5 = 1.0f64 / (0.5 * omega[2]).tan();
-
-        // (44), k={1,3,5}
-        let r_1 = p_1 * p_1 / omega[0].sin();
-        let r_3 = -p_3 * p_3 / omega[1].sin();
-        let r_5 = p_5 * p_5 / omega[2].sin();
-
-        // (50), k={1,3,5}
-        let neg_half_sigma2 = -0.5f64 * SIGMA * SIGMA;
-        let recip_radius = 1.0f64 / radius;
-        let mut rho = [0.0f64; 3];
-        for i in 0..3 {
-            rho[i] = (neg_half_sigma2 * omega[i] * omega[i]).exp() * recip_radius;
-        }
-
-        // second part of (52), k1,k2 = 1,3; 3,5; 5,1
-        let d_13 = p_1.mul_add(r_3, -r_1 * p_3);
-        let d_35 = p_3.mul_add(r_5, -r_3 * p_5);
-        let d_51 = p_5.mul_add(r_1, -r_5 * p_1);
-
-        // (52), k=5
-        let recip_d13 = 1.0f64 / d_13;
-        let zeta_15 = d_35 * recip_d13;
-        let zeta_35 = d_51 * recip_d13;
-
-        // (56)
-        let a = Matrix3::from_row_slice(&[p_1, p_3, p_5, r_1, r_3, r_5, zeta_15, zeta_35, 1.0f64])
-            .try_inverse()
-            .expect("Has inverse");
-        // (55)
-        let gamma = Matrix3x1::from_column_slice(&[
-            1.0f64,
-            radius.mul_add(radius, -SIGMA * SIGMA),
-            zeta_15.mul_add(rho[0], zeta_35 * rho[1]) + rho[2],
-        ]);
-        // (53)
-        let beta = a * gamma;
-
-        // Sanity check: correctly solved for beta (IIR filter weights are normalized)
-        // (39)
-        let sum = beta[2].mul_add(p_5, beta[0].mul_add(p_1, beta[1] * p_3));
-        assert!((sum - 1.0).abs() < 1E-12f64);
-
-        let mut n2 = [0f64; 3];
-        let mut d1 = [0f64; 3];
-        let mut mul_prev = [0f32; 3 * 4];
-        let mut mul_prev2 = [0f32; 3 * 4];
-        let mut mul_in = [0f32; 3 * 4];
-        for i in 0..3 {
-            // (33)
-            n2[i] = -beta[i] * (omega[i] * (radius + 1.0)).cos();
-            d1[i] = -2.0f64 * omega[i].cos();
-
-            let d_2 = d1[i] * d1[i];
-
-            // Obtained by expanding (35) for four consecutive outputs via
-            // sympy: n, d, p, pp = symbols('n d p pp')
-            // i0, i1, i2, i3 = symbols('i0 i1 i2 i3')
-            // o0, o1, o2, o3 = symbols('o0 o1 o2 o3')
-            // o0 = n*i0 - d*p - pp
-            // o1 = n*i1 - d*o0 - p
-            // o2 = n*i2 - d*o1 - o0
-            // o3 = n*i3 - d*o2 - o1
-            // Then expand(o3) and gather terms for p(prev), pp(prev2) etc.
-            mul_prev[4 * i] = -d1[i] as f32;
-            mul_prev[4 * i + 1] = (d_2 - 1.0f64) as f32;
-            mul_prev[4 * i + 2] = (-d_2).mul_add(d1[i], 2.0f64 * d1[i]) as f32;
-            mul_prev[4 * i + 3] = d_2.mul_add(d_2, 3.0f64.mul_add(-d_2, 1.0f64)) as f32;
-            mul_prev2[4 * i] = -1.0f32;
-            mul_prev2[4 * i + 1] = d1[i] as f32;
-            mul_prev2[4 * i + 2] = (-d_2 + 1.0f64) as f32;
-            mul_prev2[4 * i + 3] = d_2.mul_add(d1[i], -2.0f64 * d1[i]) as f32;
-            mul_in[4 * i] = n2[i] as f32;
-            mul_in[4 * i + 1] = (-d1[i] * n2[i]) as f32;
-            mul_in[4 * i + 2] = d_2.mul_add(n2[i], -n2[i]) as f32;
-            mul_in[4 * i + 3] = (-d_2 * d1[i]).mul_add(n2[i], 2.0f64 * d1[i] * n2[i]) as f32;
-        }
-
-        Self {
-            radius: radius as usize,
-            vert_mul_in: n2.map(|f| f as f32),
-            vert_mul_prev: d1.map(|f| f as f32),
-            mul_prev: Aligned(mul_prev),
-            mul_prev2: Aligned(mul_prev2),
-            mul_in: Aligned(mul_in),
-        }
-    }
-
     #[cfg(feature = "rayon")]
     pub fn horizontal_pass(&self, input: &[f32], output: &mut [f32], width: usize) {
         use rayon::iter::{IndexedParallelIterator, ParallelIterator};
@@ -151,16 +32,7 @@ impl RecursiveGaussian {
     }
 
     fn horizontal_row(&self, input: &[f32], output: &mut [f32], width: usize) {
-        let big_n = self.radius as isize;
-        let mul_in_1 = self.mul_in[0];
-        let mul_in_3 = self.mul_in[4];
-        let mul_in_5 = self.mul_in[8];
-        let mul_prev_1 = self.mul_prev[0];
-        let mul_prev_3 = self.mul_prev[4];
-        let mul_prev_5 = self.mul_prev[8];
-        let mul_prev2_1 = self.mul_prev2[0];
-        let mul_prev2_3 = self.mul_prev2[4];
-        let mul_prev2_5 = self.mul_prev2[8];
+        let big_n = RADIUS as isize;
         let mut prev_1 = 0f32;
         let mut prev_3 = 0f32;
         let mut prev_5 = 0f32;
@@ -186,20 +58,20 @@ impl RecursiveGaussian {
             };
             let sum = left_val + right_val;
 
-            let mut out_1 = sum * mul_in_1;
-            let mut out_3 = sum * mul_in_3;
-            let mut out_5 = sum * mul_in_5;
+            let mut out_1 = sum * MUL_IN_1;
+            let mut out_3 = sum * MUL_IN_3;
+            let mut out_5 = sum * MUL_IN_5;
 
-            out_1 = mul_prev2_1.mul_add(prev2_1, out_1);
-            out_3 = mul_prev2_3.mul_add(prev2_3, out_3);
-            out_5 = mul_prev2_5.mul_add(prev2_5, out_5);
+            out_1 = MUL_PREV2_1.mul_add(prev2_1, out_1);
+            out_3 = MUL_PREV2_3.mul_add(prev2_3, out_3);
+            out_5 = MUL_PREV2_5.mul_add(prev2_5, out_5);
             prev2_1 = prev_1;
             prev2_3 = prev_3;
             prev2_5 = prev_5;
 
-            out_1 = mul_prev_1.mul_add(prev_1, out_1);
-            out_3 = mul_prev_3.mul_add(prev_3, out_3);
-            out_5 = mul_prev_5.mul_add(prev_5, out_5);
+            out_1 = MUL_PREV_1.mul_add(prev_1, out_1);
+            out_3 = MUL_PREV_3.mul_add(prev_3, out_3);
+            out_5 = MUL_PREV_5.mul_add(prev_5, out_5);
             prev_1 = out_1;
             prev_3 = out_3;
             prev_5 = out_5;
@@ -255,7 +127,7 @@ impl RecursiveGaussian {
     ) {
         assert_eq!(input.len(), output.len());
 
-        let big_n = self.radius as isize;
+        let big_n = RADIUS as isize;
 
         let zeroes = vec![0f32; COLUMNS];
         let mut prev = vec![0f32; 3 * COLUMNS];
@@ -285,21 +157,13 @@ impl RecursiveGaussian {
                 let i3 = i1 + COLUMNS;
                 let i5 = i3 + COLUMNS;
 
-                let mp1 = self.vert_mul_prev[0];
-                let mp3 = self.vert_mul_prev[1];
-                let mp5 = self.vert_mul_prev[2];
+                let out1 = prev[i1].mul_add(VERT_MUL_PREV_1, prev2[i1]);
+                let out3 = prev[i3].mul_add(VERT_MUL_PREV_3, prev2[i3]);
+                let out5 = prev[i5].mul_add(VERT_MUL_PREV_5, prev2[i5]);
 
-                let out1 = prev[i1].mul_add(mp1, prev2[i1]);
-                let out3 = prev[i3].mul_add(mp3, prev2[i3]);
-                let out5 = prev[i5].mul_add(mp5, prev2[i5]);
-
-                let mi1 = self.vert_mul_in[0];
-                let mi3 = self.vert_mul_in[1];
-                let mi5 = self.vert_mul_in[2];
-
-                let out1 = sum.mul_add(mi1, -out1);
-                let out3 = sum.mul_add(mi3, -out3);
-                let out5 = sum.mul_add(mi5, -out5);
+                let out1 = sum.mul_add(VERT_MUL_IN_1, -out1);
+                let out3 = sum.mul_add(VERT_MUL_IN_3, -out3);
+                let out5 = sum.mul_add(VERT_MUL_IN_5, -out5);
 
                 out[i1] = out1;
                 out[i3] = out3;

--- a/src/blur/gaussian.rs
+++ b/src/blur/gaussian.rs
@@ -1,4 +1,7 @@
-include!(concat!(env!("OUT_DIR"), "/recursive_gaussian.rs"));
+mod consts {
+    #![allow(clippy::unreadable_literal)]
+    include!(concat!(env!("OUT_DIR"), "/recursive_gaussian.rs"));
+}
 
 /// Implements "Recursive Implementation of the Gaussian Filter Using Truncated
 /// Cosine Functions" by Charalampidis [2016].
@@ -32,7 +35,7 @@ impl RecursiveGaussian {
     }
 
     fn horizontal_row(&self, input: &[f32], output: &mut [f32], width: usize) {
-        let big_n = RADIUS as isize;
+        let big_n = consts::RADIUS as isize;
         let mut prev_1 = 0f32;
         let mut prev_3 = 0f32;
         let mut prev_5 = 0f32;
@@ -58,20 +61,20 @@ impl RecursiveGaussian {
             };
             let sum = left_val + right_val;
 
-            let mut out_1 = sum * MUL_IN_1;
-            let mut out_3 = sum * MUL_IN_3;
-            let mut out_5 = sum * MUL_IN_5;
+            let mut out_1 = sum * consts::MUL_IN_1;
+            let mut out_3 = sum * consts::MUL_IN_3;
+            let mut out_5 = sum * consts::MUL_IN_5;
 
-            out_1 = MUL_PREV2_1.mul_add(prev2_1, out_1);
-            out_3 = MUL_PREV2_3.mul_add(prev2_3, out_3);
-            out_5 = MUL_PREV2_5.mul_add(prev2_5, out_5);
+            out_1 = consts::MUL_PREV2_1.mul_add(prev2_1, out_1);
+            out_3 = consts::MUL_PREV2_3.mul_add(prev2_3, out_3);
+            out_5 = consts::MUL_PREV2_5.mul_add(prev2_5, out_5);
             prev2_1 = prev_1;
             prev2_3 = prev_3;
             prev2_5 = prev_5;
 
-            out_1 = MUL_PREV_1.mul_add(prev_1, out_1);
-            out_3 = MUL_PREV_3.mul_add(prev_3, out_3);
-            out_5 = MUL_PREV_5.mul_add(prev_5, out_5);
+            out_1 = consts::MUL_PREV_1.mul_add(prev_1, out_1);
+            out_3 = consts::MUL_PREV_3.mul_add(prev_3, out_3);
+            out_5 = consts::MUL_PREV_5.mul_add(prev_5, out_5);
             prev_1 = out_1;
             prev_3 = out_3;
             prev_5 = out_5;
@@ -127,7 +130,7 @@ impl RecursiveGaussian {
     ) {
         assert_eq!(input.len(), output.len());
 
-        let big_n = RADIUS as isize;
+        let big_n = consts::RADIUS as isize;
 
         let zeroes = vec![0f32; COLUMNS];
         let mut prev = vec![0f32; 3 * COLUMNS];
@@ -157,13 +160,13 @@ impl RecursiveGaussian {
                 let i3 = i1 + COLUMNS;
                 let i5 = i3 + COLUMNS;
 
-                let out1 = prev[i1].mul_add(VERT_MUL_PREV_1, prev2[i1]);
-                let out3 = prev[i3].mul_add(VERT_MUL_PREV_3, prev2[i3]);
-                let out5 = prev[i5].mul_add(VERT_MUL_PREV_5, prev2[i5]);
+                let out1 = prev[i1].mul_add(consts::VERT_MUL_PREV_1, prev2[i1]);
+                let out3 = prev[i3].mul_add(consts::VERT_MUL_PREV_3, prev2[i3]);
+                let out5 = prev[i5].mul_add(consts::VERT_MUL_PREV_5, prev2[i5]);
 
-                let out1 = sum.mul_add(VERT_MUL_IN_1, -out1);
-                let out3 = sum.mul_add(VERT_MUL_IN_3, -out3);
-                let out5 = sum.mul_add(VERT_MUL_IN_5, -out5);
+                let out1 = sum.mul_add(consts::VERT_MUL_IN_1, -out1);
+                let out3 = sum.mul_add(consts::VERT_MUL_IN_3, -out3);
+                let out5 = sum.mul_add(consts::VERT_MUL_IN_5, -out5);
 
                 out[i1] = out1;
                 out[i3] = out3;

--- a/src/blur/mod.rs
+++ b/src/blur/mod.rs
@@ -1,0 +1,60 @@
+mod gaussian;
+
+use gaussian::RecursiveGaussian;
+
+/// Structure handling image blur.
+///
+/// This struct contains the necessary buffers and the kernel used for blurring
+/// (currently a recursive approximation of the Gaussian filter).
+/// 
+/// Note that the width and height of the image passed to [blur][Self::blur] needs to exactly
+/// match the width and height of this instance. If you reduce the image size (e.g. via
+/// downscaling), [`shrink_to`][Self::shrink_to] can be used to resize the internal buffers.
+pub struct Blur {
+    kernel: RecursiveGaussian,
+    temp: Vec<f32>,
+    width: usize,
+    height: usize,
+}
+
+impl Blur {
+    /// Create a new [Blur] for images of the given width and height.
+    /// This pre-allocates the necessary buffers.
+    #[must_use]
+    pub fn new(width: usize, height: usize) -> Self {
+        Blur {
+            kernel: RecursiveGaussian::new(),
+            temp: vec![0.0f32; width * height],
+            width,
+            height,
+        }
+    }
+
+    /// Truncates the internal buffers to fit images of the given width and height.
+    /// 
+    /// This will [truncate][Vec::truncate] the internal buffers
+    /// without affecting the allocated memory.
+    pub fn shrink_to(&mut self, width: usize, height: usize) {
+        self.temp.truncate(width * height);
+        self.width = width;
+        self.height = height;
+    }
+
+    /// Blur the given image.
+    pub fn blur(&mut self, img: &[Vec<f32>; 3]) -> [Vec<f32>; 3] {
+        [
+            self.blur_plane(&img[0]),
+            self.blur_plane(&img[1]),
+            self.blur_plane(&img[2]),
+        ]
+    }
+
+    fn blur_plane(&mut self, plane: &[f32]) -> Vec<f32> {
+        let mut out = vec![0f32; self.width * self.height];
+        self.kernel
+            .horizontal_pass(plane, &mut self.temp, self.width);
+        self.kernel
+            .vertical_pass_chunked::<128, 32>(&self.temp, &mut out, self.width, self.height);
+        out
+    }
+}

--- a/src/blur/mod.rs
+++ b/src/blur/mod.rs
@@ -6,7 +6,7 @@ use gaussian::RecursiveGaussian;
 ///
 /// This struct contains the necessary buffers and the kernel used for blurring
 /// (currently a recursive approximation of the Gaussian filter).
-/// 
+///
 /// Note that the width and height of the image passed to [blur][Self::blur] needs to exactly
 /// match the width and height of this instance. If you reduce the image size (e.g. via
 /// downscaling), [`shrink_to`][Self::shrink_to] can be used to resize the internal buffers.
@@ -23,7 +23,7 @@ impl Blur {
     #[must_use]
     pub fn new(width: usize, height: usize) -> Self {
         Blur {
-            kernel: RecursiveGaussian::new(),
+            kernel: RecursiveGaussian,
             temp: vec![0.0f32; width * height],
             width,
             height,
@@ -31,7 +31,7 @@ impl Blur {
     }
 
     /// Truncates the internal buffers to fit images of the given width and height.
-    /// 
+    ///
     /// This will [truncate][Vec::truncate] the internal buffers
     /// without affecting the allocated memory.
     pub fn shrink_to(&mut self, width: usize, height: usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 #![warn(clippy::lossy_float_literal)]
 #![warn(clippy::map_err_ignore)]
 #![warn(clippy::mem_forget)]
-#![warn(clippy::mod_module_files)]
 #![warn(clippy::multiple_inherent_impl)]
 #![warn(clippy::pattern_type_mismatch)]
 #![warn(clippy::rc_buffer)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::struct_excessive_bools)]
 #![allow(clippy::use_self)]
+#![allow(clippy::unused_self)]
 #![warn(clippy::clone_on_ref_ptr)]
 #![warn(clippy::create_dir)]
 #![warn(clippy::dbg_macro)]


### PR DESCRIPTION
`RecursiveGaussian::new` does calculations that are always based on the same constant values defined at compile-time. My first thought was to just inline these, but that would make maintaining the algorithm a lot more difficult.

This PR adds a simple build script that does the same as `RecursiveGaussian::new` and writes the resulting values to const variables:

```rust
mod consts {
  pub const RADIUS: usize = 5_usize;
  pub const VERT_MUL_IN_1: f32 = 0.055295236_f32;
  pub const VERT_MUL_IN_3: f32 = -0.058836687_f32;
  pub const VERT_MUL_IN_5: f32 = 0.012955819_f32;
  pub const VERT_MUL_PREV_1: f32 = -1.9021131_f32;
  pub const VERT_MUL_PREV_3: f32 = -1.1755705_f32;
  pub const VERT_MUL_PREV_5: f32 = -0.00000000000000012246469_f32;
  pub const MUL_IN_1: f32 = 0.055295236_f32;
  pub const MUL_IN_3: f32 = -0.058836687_f32;
  pub const MUL_IN_5: f32 = 0.012955819_f32;
  pub const MUL_PREV_1: f32 = 1.9021131_f32;
  pub const MUL_PREV_3: f32 = 1.1755705_f32;
  pub const MUL_PREV_5: f32 = 0.00000000000000012246469_f32;
  pub const MUL_PREV2_1: f32 = -1_f32;
  pub const MUL_PREV2_3: f32 = -1_f32;
  pub const MUL_PREV2_5: f32 = -1_f32;
}
```

The `RecursiveGaussian` can then use these consts instead of `self.asdf` in the blur algorithm.

I understand that there is a reason that float calculations are not `const` in Rust (even though integer calculations are), but by my testing, even platforms without FMA produce the exact same variable values. Maybe more testing is needed on ARM and maybe Windows platforms (due to their x87 FPU shenanigans that might apply here). But I think that even if there are inconsistencies, they're probably smaller than the inaccuracies the algorithm itself would produce at runtime anyways.

I have no clue why I never tested this before. The results are staggering for the amount of effort needed:
```
blur                    time:   [9.0900 ms 9.1005 ms 9.1112 ms]
                        change: [-36.050% -35.935% -35.820%] (p = 0.00 < 0.05)
                        Performance has improved.
```

This also reduces the resulting library size (very roughly 20%), mostly because of nalgebra being removed from runtime.
