### PR TITLE
Update yuvxyb from 0.3 to 0.4

### DIFF
--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anyhow"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,12 +495,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-bigint"
@@ -1082,17 +1070,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yuvxyb"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ddc63ff08dbe6fdc05b3e438dcfacbea8f8fcd694b0731c556b60704ab4604"
+checksum = "838b59f140accc874683473ab67aae5a5896465287652e929521c180896af0e4"
 dependencies = [
- "anyhow",
  "av-data",
  "log",
  "nalgebra",
- "new_debug_unreachable",
  "num-traits",
  "paste",
+ "thiserror",
  "v_frame",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["rayon"]
 num-traits = "0.2.15"
 rayon = { version = "1.5.3", optional = true }
 thiserror = "1.0.56"
-yuvxyb = "0.3.0"
+yuvxyb = "0.4.0"
 
 [build-dependencies]
 nalgebra = "0.32.2"


### PR DESCRIPTION
[List of changes](https://github.com/rust-av/yuvxyb/compare/v0.3.0...v0.4.0)

Notable:
- Slimmed down dependencies
- Better docs
- New error types (not used directly, but exposed through `pub use yuvxyb::`)