### PR TITLE
fix(bin): lcms2 panic on 16-bit PNGs with an ICC profile

### DIFF
--- a/ssimulacra2_bin/src/icc.rs
+++ b/ssimulacra2_bin/src/icc.rs
@@ -136,12 +136,12 @@ fn decode_png_16bit(
     let rgb_u16 = apply_icc_transform_u16(rgb_u16, icc_profile);
 
     let pixels: Vec<[f32; 3]> = rgb_u16
-        .chunks_exact(3)
-        .map(|c| {
+        .iter()
+        .map(|px| {
             [
-                c[0] as f32 / 65535.0,
-                c[1] as f32 / 65535.0,
-                c[2] as f32 / 65535.0,
+                px[0] as f32 / 65535.0,
+                px[1] as f32 / 65535.0,
+                px[2] as f32 / 65535.0,
             ]
         })
         .collect();
@@ -197,8 +197,8 @@ fn extract_rgb_alpha_u16(
     channels: usize,
     has_alpha: bool,
     is_grayscale: bool,
-) -> (Vec<u16>, Option<Vec<f32>>) {
-    let mut rgb = Vec::with_capacity(pixel_count * 3);
+) -> (Vec<[u16; 3]>, Option<Vec<f32>>) {
+    let mut rgb = Vec::with_capacity(pixel_count);
     let mut alpha = if has_alpha {
         Some(Vec::with_capacity(pixel_count))
     } else {
@@ -209,17 +209,17 @@ fn extract_rgb_alpha_u16(
         let base = i * channels * 2;
         if is_grayscale {
             let g = u16::from_be_bytes([raw[base], raw[base + 1]]);
-            rgb.push(g);
-            rgb.push(g);
-            rgb.push(g);
+            rgb.push([g, g, g]);
             if has_alpha {
                 let a = u16::from_be_bytes([raw[base + 2], raw[base + 3]]);
                 alpha.as_mut().unwrap().push(a as f32 / 65535.0);
             }
         } else {
-            rgb.push(u16::from_be_bytes([raw[base], raw[base + 1]]));
-            rgb.push(u16::from_be_bytes([raw[base + 2], raw[base + 3]]));
-            rgb.push(u16::from_be_bytes([raw[base + 4], raw[base + 5]]));
+            rgb.push([
+                u16::from_be_bytes([raw[base], raw[base + 1]]),
+                u16::from_be_bytes([raw[base + 2], raw[base + 3]]),
+                u16::from_be_bytes([raw[base + 4], raw[base + 5]]),
+            ]);
             if has_alpha {
                 let a = u16::from_be_bytes([raw[base + 6], raw[base + 7]]);
                 alpha.as_mut().unwrap().push(a as f32 / 65535.0);
@@ -269,7 +269,7 @@ fn apply_icc_transform_u8(rgb: Vec<u8>, icc_profile: &Option<Vec<u8>>) -> Vec<u8
     dst
 }
 
-fn apply_icc_transform_u16(rgb: Vec<u16>, icc_profile: &Option<Vec<u8>>) -> Vec<u16> {
+fn apply_icc_transform_u16(rgb: Vec<[u16; 3]>, icc_profile: &Option<Vec<u8>>) -> Vec<[u16; 3]> {
     let Some(icc_data) = icc_profile else {
         return rgb;
     };
@@ -304,15 +304,11 @@ fn apply_icc_transform_u16(rgb: Vec<u16>, icc_profile: &Option<Vec<u8>>) -> Vec<
     };
 
     // lcms2-rs asserts that the element type size matches the pixel size:
-    // RGB_16 is 6 bytes per pixel, so we must transform [u16; 3] pixels, not
-    // bare u16 (only u8 slices are special-cased).
-    let src_pixels: Vec<[u16; 3]> = rgb
-        .chunks_exact(3)
-        .map(|c| [c[0], c[1], c[2]])
-        .collect();
-    let mut dst_pixels = vec![[0u16; 3]; src_pixels.len()];
-    transform.transform_pixels(&src_pixels, &mut dst_pixels);
-    dst_pixels.into_iter().flatten().collect()
+    // RGB_16 is 6 bytes per pixel, so the buffers must hold [u16; 3] pixels,
+    // not bare u16 (only u8 slices are special-cased).
+    let mut dst = vec![[0u16; 3]; rgb.len()];
+    transform.transform_pixels(&rgb, &mut dst);
+    dst
 }
 
 /// Naive CMYK -> RGB conversion, ignoring color management. Used when no usable

--- a/ssimulacra2_bin/src/icc.rs
+++ b/ssimulacra2_bin/src/icc.rs
@@ -303,9 +303,16 @@ fn apply_icc_transform_u16(rgb: Vec<u16>, icc_profile: &Option<Vec<u8>>) -> Vec<
         }
     };
 
-    let mut dst = vec![0u16; rgb.len()];
-    transform.transform_pixels(&rgb, &mut dst);
-    dst
+    // lcms2-rs asserts that the element type size matches the pixel size:
+    // RGB_16 is 6 bytes per pixel, so we must transform [u16; 3] pixels, not
+    // bare u16 (only u8 slices are special-cased).
+    let src_pixels: Vec<[u16; 3]> = rgb
+        .chunks_exact(3)
+        .map(|c| [c[0], c[1], c[2]])
+        .collect();
+    let mut dst_pixels = vec![[0u16; 3]; src_pixels.len()];
+    transform.transform_pixels(&src_pixels, &mut dst_pixels);
+    dst_pixels.into_iter().flatten().collect()
 }
 
 /// Naive CMYK -> RGB conversion, ignoring color management. Used when no usable

--- a/ssimulacra2_bin/tests/icc_16bit.rs
+++ b/ssimulacra2_bin/tests/icc_16bit.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn fixture(name: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../ssimulacra2/test_data")
+        .join(name)
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+fn score_with(args: &[&str]) -> f64 {
+    let out = Command::new(env!("CARGO_BIN_EXE_ssimulacra2_rs"))
+        .args(args)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "exit {:?}, stderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .find_map(|l| l.strip_prefix("Score: "))
+        .expect("no Score line")
+        .trim()
+        .parse()
+        .unwrap()
+}
+
+// tank_distorted.png is a 16-bit RGB PNG with an iCCP chunk: the 16-bit ICC
+// path must work (regression: lcms2 panic "PixelFormat(...) has 6 bytes per
+// pixel, but the input format has 2").
+#[test]
+fn icc_transform_on_16bit_png_does_not_crash() {
+    let src = fixture("tank_source.png");
+    let dst = fixture("tank_distorted.png");
+    let with_icc = score_with(&["image", &src, &dst]);
+    let without_icc = score_with(&["image", "--no-icc", &src, &dst]);
+    // The embedded profile is sRGB: the conversion should be nearly neutral.
+    assert!(
+        (with_icc - without_icc).abs() < 0.25,
+        "icc {with_icc} vs no-icc {without_icc}"
+    );
+}


### PR DESCRIPTION
Scoring any 16-bit PNG that embeds an ICC profile panics since #31:

```
thread 'main' panicked at lcms2-6.1.1/src/transform.rs:84:9:
assertion `left == right` failed: PixelFormat(262170) has 6 bytes per pixel, but the input format has 2
```

This includes the bundled test pair: `ssimulacra2_rs image tank_source.png tank_distorted.png` crashes at current HEAD (`tank_distorted.png` is 16-bit RGB with an iCCP chunk).

**Cause:** `apply_icc_transform_u16` builds a `Transform<u16, u16>` with `PixelFormat::RGB_16`. lcms2-rs asserts that the element type size matches the pixel size (6 bytes for RGB_16); only `u8` slices are special-cased, which is why the 8-bit path works.

**Fix:** transform `[u16; 3]` pixels instead of bare `u16`.

Includes a regression test that runs the `image` command on the tank pair and checks the score against `--no-icc` (the embedded profile is sRGB, so the conversion should be nearly neutral; observed delta is ~0.008).
