### PR TITLE
feat(bin): enable the lib's rayon feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "700cb4e17f98c3f36756815b18dbec2b2e3c4f5028e9cdee3e23dd8c285e736c"
 dependencies = [
  "num-traits",
+ "rayon",
  "thiserror 2.0.18",
  "yuvxyb",
  "yuvxyb-math",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,6 +2054,7 @@ dependencies = [
  "num-traits",
  "plotters",
  "png",
+ "rayon",
  "ssimulacra2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "statrs",
 ]

--- a/ssimulacra2_bin/Cargo.toml
+++ b/ssimulacra2_bin/Cargo.toml
@@ -21,7 +21,7 @@ jpeg-decoder = "0.3"
 lcms2 = "6.1"
 num-traits = { version = "0.2.15", optional = true }
 png = "0.18"
-ssimulacra2 = { version = "0.5.0", default-features = false }
+ssimulacra2 = { version = "0.5.0", default-features = false, features = ["rayon"] }
 statrs = { version = "0.17.0", optional = true }
 
 [dependencies.image]

--- a/ssimulacra2_bin/Cargo.toml
+++ b/ssimulacra2_bin/Cargo.toml
@@ -22,7 +22,7 @@ lcms2 = "6.1"
 num-traits = { version = "0.2.15", optional = true }
 png = "0.18"
 rayon = { version = "1", optional = true }
-ssimulacra2 = { version = "0.5.0", default-features = false, features = ["rayon"] }
+ssimulacra2 = "0.5.0"
 statrs = { version = "0.17.0", optional = true }
 
 [dependencies.image]

--- a/ssimulacra2_bin/Cargo.toml
+++ b/ssimulacra2_bin/Cargo.toml
@@ -21,6 +21,7 @@ jpeg-decoder = "0.3"
 lcms2 = "6.1"
 num-traits = { version = "0.2.15", optional = true }
 png = "0.18"
+rayon = { version = "1", optional = true }
 ssimulacra2 = { version = "0.5.0", default-features = false, features = ["rayon"] }
 statrs = { version = "0.17.0", optional = true }
 
@@ -37,7 +38,7 @@ optional = true
 
 [features]
 default = ["video", "avif"]
-video = ["av-metrics-decoders", "plotters", "statrs", "num-traits"]
+video = ["av-metrics-decoders", "plotters", "statrs", "num-traits", "dep:rayon"]
 avif = ["image/avif-native"]
 
 [lints]

--- a/ssimulacra2_bin/src/video.rs
+++ b/ssimulacra2_bin/src/video.rs
@@ -404,7 +404,17 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
         let result_tx = result_tx.clone();
 
         std::thread::spawn(move || {
-            loop {
+            // Frame-level threading already saturates the CPU here; the lib's
+            // rayon feature must not multiply it (see ssimulacra2_bin#21).
+            // Running this worker inside a single-threaded local pool keeps
+            // the lib's rayon code path sequential per frame, so video-mode
+            // behavior and CPU usage match the previous non-rayon build,
+            // while image mode gets the default (parallel) pool.
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .expect("failed to build single-threaded rayon pool");
+            pool.install(|| loop {
                 let score = match (src_bd, dst_bd) {
                     (8, 8) => calc_score::<u8, u8, _, _>(
                         &video_compare,
@@ -446,7 +456,7 @@ fn compare_videos_inner<D: Decoder + 'static, E: Decoder + 'static>(
                     // no score = no more frames to read
                     break;
                 }
-            }
+            });
         });
     }
 


### PR DESCRIPTION
The binary depends on the lib with `default-features = false`, which silently disables the lib's `rayon` feature (on by default, used for the parallel horizontal blur pass) for every install of the CLI, however it is built. `cargo install ssimulacra2_rs` therefore always produces a fully single-threaded scorer.

This PR turns the feature back on for the binary: `default-features = false, features = ["rayon"]`.

Measured with hyperfine (10 runs, Core Ultra 7 155H, Linux) on a 1448×1080 pair with `ssimulacra2_rs image`:

| | mean ± σ |
|---|---|
| before | 1.231 s ± 0.014 |
| after | 1.013 s ± 0.044 |

No score or output change (the parallel rows keep their per-row summation order).

There is more parallelism available in the rest of the pipeline (vertical pass, planes, downscale, maps); happy to follow up with that work if there's interest — this one-liner is the zero-risk part.
